### PR TITLE
Pod prefix

### DIFF
--- a/pkg/cmd/evict_pod.go
+++ b/pkg/cmd/evict_pod.go
@@ -73,14 +73,12 @@ func NewCmdModifySecret(streams genericclioptions.IOStreams) *cobra.Command {
 // Complete sets all information required for updating the current context
 func (o *EvictPodOptions) Complete(cmd *cobra.Command, args []string) error {
 
-	if len(args) > 0 {
-
-		o.podNames = append(o.podNames, args[0])
+	if len(args) == 0 {
+		cmd.Help()
+		os.Exit(0)
 	}
 
-	if len(args) > 1 {
-		o.podNames = args
-	}
+	o.podNames = args
 
 	config, err := o.configFlags.ToRESTConfig()
 	if err != nil {

--- a/pkg/cmd/evict_pod.go
+++ b/pkg/cmd/evict_pod.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rajatjindal/kubectl-evict-pod/pkg/k8s"
 	"github.com/sirupsen/logrus"
@@ -117,6 +118,9 @@ func (o *EvictPodOptions) Run() error {
 	}
 
 	for _, podName := range o.podNames {
+		// remove the 'pod/' prefix, if it exists
+		podName = strings.TrimPrefix(podName, "pod/")
+
 		err := k8s.Evict(o.kubeclient, podName, o.namespace)
 		if err != nil {
 			return err

--- a/pkg/cmd/evict_pod.go
+++ b/pkg/cmd/evict_pod.go
@@ -20,11 +20,11 @@ type EvictPodOptions struct {
 	configFlags *genericclioptions.ConfigFlags
 	iostreams   genericclioptions.IOStreams
 
-	args         []string
-	podName      string
+	podNames     []string
 	namespace    string
 	kubeclient   kubernetes.Interface
 	printVersion bool
+	label        string
 }
 
 // NewEvictPodOptions provides an instance of EvictPodOptions with default values
@@ -64,6 +64,7 @@ func NewCmdModifySecret(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&o.printVersion, "version", false, "prints version of plugin")
+	cmd.Flags().StringVar(&o.label, "label", "", "specify a label to evict pods with")
 	o.configFlags.AddFlags(cmd.Flags())
 
 	return cmd
@@ -71,10 +72,14 @@ func NewCmdModifySecret(streams genericclioptions.IOStreams) *cobra.Command {
 
 // Complete sets all information required for updating the current context
 func (o *EvictPodOptions) Complete(cmd *cobra.Command, args []string) error {
-	o.args = args
 
-	if len(o.args) > 0 {
-		o.podName = o.args[0]
+	if len(args) > 0 {
+
+		o.podNames = append(o.podNames, args[0])
+	}
+
+	if len(args) > 1 {
+		o.podNames = args
 	}
 
 	config, err := o.configFlags.ToRESTConfig()
@@ -93,8 +98,9 @@ func (o *EvictPodOptions) Complete(cmd *cobra.Command, args []string) error {
 
 // Validate ensures that all required arguments and flag values are provided
 func (o *EvictPodOptions) Validate() error {
-	if len(o.args) != 1 {
-		return fmt.Errorf("only one argument expected. got %d arguments", len(o.args))
+
+	if len(o.podNames) > 0 && o.label != "" {
+		return fmt.Errorf("pod name cannot be provided when a selector is specified")
 	}
 
 	return nil
@@ -102,12 +108,24 @@ func (o *EvictPodOptions) Validate() error {
 
 // Run fetches the given secret manifest from the cluster, decodes the payload, opens an editor to make changes, and applies the modified manifest when done
 func (o *EvictPodOptions) Run() error {
-	err := k8s.Evict(o.kubeclient, o.podName, o.namespace)
-	if err != nil {
-		return err
+	var err error
+
+	if o.label != "" {
+
+		o.podNames, err = k8s.PodsFromLabel(o.kubeclient, o.label, o.namespace)
+		if err != nil {
+			return err
+		}
 	}
 
-	logrus.Infof("pod %q in namespace %s evicted successfully", o.podName, o.namespace)
+	for _, podName := range o.podNames {
+		err := k8s.Evict(o.kubeclient, podName, o.namespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	logrus.Infof("pods %q in namespace %s evicted successfully", o.podNames, o.namespace)
 	return nil
 }
 

--- a/pkg/cmd/evict_pod.go
+++ b/pkg/cmd/evict_pod.go
@@ -123,9 +123,10 @@ func (o *EvictPodOptions) Run() error {
 		if err != nil {
 			return err
 		}
+
+		logrus.Infof("pod %s in namespace %s evicted successfully", podName, o.namespace)
 	}
 
-	logrus.Infof("pods %q in namespace %s evicted successfully", o.podNames, o.namespace)
 	return nil
 }
 

--- a/pkg/k8s/podsFromLabel.go
+++ b/pkg/k8s/podsFromLabel.go
@@ -1,0 +1,23 @@
+package k8s
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+//get pods from labelSelector
+func PodsFromLabel(kubeclient kubernetes.Interface, label, namespace string) ([]string, error) {
+
+	podList, err := kubeclient.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: label})
+	if err != nil {
+		return nil, err
+	}
+
+	var podNames []string
+
+	for _, pod := range podList.Items {
+		podNames = append(podNames, pod.Name)
+	}
+
+	return podNames, nil
+}


### PR DESCRIPTION
Mergeable after https://github.com/rajatjindal/kubectl-evict-pod/pull/8.

Fixes https://github.com/rajatjindal/kubectl-evict-pod/issues/7.

This strips out a prefix of `pod/` if it exists in the request, before sending to the Kubernetes API. It overwrites the current value, but my thoughts are that there is no need for the user to care about this prefix, nor the Kubernetes API, if it exists.