### PR TITLE
add retry option to keep evicting until all initial pods are gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This plugin evicts pods:
 
 - evict single pod: `kubectl evict-pod <pod-name> -n <namespace>`
 - evict multiple pods: `kubectl evict-pod -n <namespace> -l app=foo`
+- evict multiple pods until every one is gone: `kubectl evict-pod -n <namespace> -l app=foo --retry`
 - show options: `kubectl evict-pod -h`
 
 ## Install


### PR DESCRIPTION
```
go run . --context foo -n truth-service -l project=truth-service --retry
INFO[0034] pod truth-service-app-server-d96646b4d-ck8pf in namespace truth-service evicted successfully
WARN[0041] pod truth-service-app-server-d96646b4d-m8wdb in namespace truth-service evicting failed
WARN[0041] pod truth-service-app-server-d96646b4d-zlbd2 in namespace truth-service evicting failed
WARN[0047] pod truth-service-app-server-d96646b4d-m8wdb in namespace truth-service evicting failed
WARN[0047] pod truth-service-app-server-d96646b4d-zlbd2 in namespace truth-service evicting failed
INFO[0054] pod truth-service-app-server-d96646b4d-m8wdb in namespace truth-service evicted successfully
WARN[0054] pod truth-service-app-server-d96646b4d-zlbd2 in namespace truth-service evicting failed
WARN[0059] pod truth-service-app-server-d96646b4d-zlbd2 in namespace truth-service evicting failed
WARN[0065] pod truth-service-app-server-d96646b4d-zlbd2 in namespace truth-service evicting failed
INFO[0070] pod truth-service-app-server-d96646b4d-zlbd2 in namespace truth-service evicted successfully
```
... and then it stops